### PR TITLE
Require at least Ruby 2.4

### DIFF
--- a/sorted_set.gemspec
+++ b/sorted_set.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Implements a variant of Set whose elements are sorted in ascending order}
   spec.homepage      = "https://github.com/knu/sorted_set"
   spec.license       = "BSD-2-Clause"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
In https://github.com/knu/sorted_set/commit/497da58b965fc3ba50123786e2e6e6fc8bda0a16, you added a top-level return in case we are running on JRuby. This top-level return however is only supported since Ruby 2.4 (following https://bugs.ruby-lang.org/issues/4840)

Accordingly, trying to require the gem in Ruby 2.3 or earlier fails with the following error message:

> lib/sorted_set.rb: lib/sorted_set.rb:5: Invalid return (SyntaxError)

This pull requests updates the declared minimum Ruby version to 2.4 so that the top-level return is guaranteed to be supported.