### PR TITLE
Fix tests for Ruby 2.4 support

### DIFF
--- a/sorted_set.gemspec
+++ b/sorted_set.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Implements a variant of Set whose elements are sorted in ascending order}
   spec.homepage      = "https://github.com/knu/sorted_set"
   spec.license       = "BSD-2-Clause"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/test/test_sorted_set.rb
+++ b/test/test_sorted_set.rb
@@ -2,6 +2,8 @@ require 'test/unit'
 require 'sorted_set'
 
 class TC_SortedSet < Test::Unit::TestCase
+  FrozenError = RuntimeError unless defined?(FrozenError)
+
   def test_sortedset
     s = SortedSet[4,5,3,1,2]
 


### PR DESCRIPTION
In Ruby 2.4 and older, there is no dedicated `FrozenError` exception. Instead, those Rubies raised a `RuntimeError` when trying to modify a frozen object.

This pull requests fixes the tests on Ruby 2.4 by "mocking" the `FrozenError` class in the scope of the test to be the `RuntimeError` class.

Note: this pull request is on top of #4 (for a more linear history). If you want to only merge this one, I can gladly move the commits around.