### PR TITLE
[Fix] SortedSet#include? returns false

### DIFF
--- a/lib/sorted_set.rb
+++ b/lib/sorted_set.rb
@@ -51,7 +51,7 @@ end
 class SortedSet < Set
   # Creates a SortedSet.  See Set.new for details.
   def initialize(*args)
-    @hash = RBTree.new
+    @hash = RBTree.new(false)
     super
   end
 end

--- a/test/test_sorted_set.rb
+++ b/test/test_sorted_set.rb
@@ -46,6 +46,10 @@ class TC_SortedSet < Test::Unit::TestCase
     assert_same(nil, ret)
     assert_equal(['four', 'one', 'three', 'two'], s.to_a)
     assert_equal(['four', 'one', 'three', 'two'], a)
+
+    s = SortedSet.new([1,2,3])
+    assert_equal(true, s.include?(1))
+    assert_equal(false, s.include?(5))
   end
 
   def test_each


### PR DESCRIPTION
For the Set gem, `@hash = Hash.new(false)`, for the SortedSet it's
initialized with a `RBTree` with no default value, which causes
the include method to return `nil` when the key is not present.

Fixing it and adding a couple of specs.