### PR TITLE
Add default value to RBTree so it behaves similarly to an unsorted set

### DIFF
--- a/lib/sorted_set.rb
+++ b/lib/sorted_set.rb
@@ -51,7 +51,7 @@ end
 class SortedSet < Set
   # Creates a SortedSet.  See Set.new for details.
   def initialize(*args)
-    @hash = RBTree.new
+    @hash = RBTree.new(false)
     super
   end
 end

--- a/test/test_sorted_set.rb
+++ b/test/test_sorted_set.rb
@@ -121,4 +121,10 @@ class TC_SortedSet < Test::Unit::TestCase
     assert_instance_of(SortedSet, set)
     assert_equal([-10,-8,-6,-4,-2], set.to_a)
   end
+
+  def test_include
+    s = SortedSet[4,5,3,1,2]
+    assert_equal(true, s.include?(4))
+    assert_equal(false, s.include?(6))
+  end
 end


### PR DESCRIPTION
Before this change:
```
pry(main)> s = SortedSet[4,5,3,1,2]
=> #<SortedSet: {1, 2, 3, 4, 5}>
pry(main)> s.include?(4)
=> true
pry(main)> s.include?(6)
=> nil
```

After this change:
```
pry(main)> s = SortedSet[4,5,3,1,2]
=> #<SortedSet: {1, 2, 3, 4, 5}>
pry(main)> s.include?(4)
=> true
pry(main)> s.include?(6)
=> false
```