### PR TITLE
Fix a build error for rbtree dependency using Ruby 3.2.0dev

### DIFF
--- a/sorted_set.gemspec
+++ b/sorted_set.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
     spec.platform = "java"
   else
     spec.add_runtime_dependency "set", "~> 1.0"
-    spec.add_runtime_dependency "rbtree"
+    spec.add_runtime_dependency "rbtree3"
   end
 end


### PR DESCRIPTION
Fixes #11.

The original rbtree gem didn't seem to be maintained anymore.
https://github.com/skade/rbtree

And a forked gem called rbtree3 solves the #11 error.

- https://rubygems.org/gems/rbtree3
- https://github.com/kyrylo/rbtree3

The PR that is resolving the build error:
https://github.com/kyrylo/rbtree3/pull/14

I'm not sure about gem replacement is the best, but the error will be resolved anyway.